### PR TITLE
missing doesExceedRequestMax(), typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,6 @@ For information on how to install this admin go to http://www.adobe.com/devnet/d
 
 For information on how to use this admin go to http://www.adobe.com/devnet/digitalpublishingsuite/articles/how-use-dps-entitlement-service.html.
 
-For information on how to test the setup of the direct entitlemtn, please read [this](SETUPTEST.md).
+For information on how to test the setup of the direct entitlement, please read [this](SETUPTEST.md).
 
 http://www.adobe.com/support/downloads/license.html

--- a/services/index.php
+++ b/services/index.php
@@ -192,4 +192,8 @@ function setXMLHeader() {
 	Header("Content-Type: application/xml; charset=utf-8");
 }
 
+function doesExceedRequestMax($mysqli, $appId) {
+	return false;
+}
+
 ?>


### PR DESCRIPTION
I suspect that doesExceedRequestMax() probably got inadvertently pulled out when cleaning up the code for release, but it not being there causes SignInWithCredentials(), RenewAuthToken() and entitlements() to throw a stack trace complaining that the function doesn't exist.  I'm not sure whether anyone outside of Adobe is going to care about the number of requests, so I just always return false.
